### PR TITLE
Fix statement of calculating minutes from second

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    working_times (0.7.0)
+    working_times (0.7.1)
       activesupport (~> 5)
       thor (~> 0.20.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,13 +16,13 @@ GEM
     ast (2.4.0)
     byebug (11.1.1)
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
-    minitest (5.12.2)
+    minitest (5.14.0)
     parallel (1.19.1)
     parser (2.7.0.4)
       ast (~> 2.4.0)
@@ -59,7 +59,7 @@ GEM
     ruby-progressbar (1.10.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
 

--- a/lib/working_times/constants.rb
+++ b/lib/working_times/constants.rb
@@ -1,5 +1,5 @@
 module WorkingTimes
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 
   START_MSG = [
     'Have a nice work!',

--- a/lib/working_times/invoice.rb
+++ b/lib/working_times/invoice.rb
@@ -111,10 +111,12 @@ module WorkingTimes
       "#{worktime.nil? ? '-' : parse_second_to_hm_str(worktime)} \\\\ \\hline"
     end
 
+    # second : Float
     def parse_second_to_hm_str(second)
-      h = (second / 3600).to_i
-      m = second - (3600 * h)
-      "#{h.to_i}:#{m.to_i.to_s.rjust(2, '0')}"
+      second = second.to_i
+      h = second / 3600
+      m = (second - 3600 * h) / 60
+      "#{h}:#{m.to_s.rjust(2, '0')}"
     end
 
     def parse_second_to_hh_str(second)


### PR DESCRIPTION
Because of wrong statement, `invoice` command creates wrong HH:MM like:

```
... & 09:53 & 16:00 & 1:00 & 5:407
                             ^^^^^
```

- [x] Fix statement
- [x] Cast to Integer before calculate